### PR TITLE
Fix skip updates

### DIFF
--- a/inline/core.py
+++ b/inline/core.py
@@ -87,7 +87,9 @@ class Inline:
         await self.bot.send_message(me.id,
                                     "🕊 <b>Fly-telegram userbot is loaded!</b>")
 
+        await self.bot.delete_webhook(drop_pending_updates=True) # skip updates
+
         asyncio.ensure_future(
             self.dispatcher.start_polling(
-                self.bot, skip_updates=True, handle_signals=False)
+                self.bot, handle_signals=False)
         )


### PR DESCRIPTION
Dispatcher.start_polling in aiogram 3.x hasn't attribute `skip_updates`
https://docs.aiogram.dev/en/dev-3.x/dispatcher/dispatcher.html#aiogram.dispatcher.dispatcher.Dispatcher.start_polling

"To skip pending updates, you should now call the [DeleteWebhook](https://docs.aiogram.dev/en/dev-3.x/api/methods/delete_webhook.html#aiogram.methods.delete_webhook.DeleteWebhook) method directly, rather than passing skip_updates=True to the start polling method." - Documentation